### PR TITLE
[Plugins] Plugin types and deferreds

### DIFF
--- a/plugins/management/__init__.py
+++ b/plugins/management/__init__.py
@@ -10,6 +10,8 @@ for more information on that.
 
 import os
 
+from twisted.internet.defer import inlineCallbacks
+
 from system.enums import PluginState, ProtocolState
 from system.plugins.plugin import PluginObject
 from system.translations import Translations
@@ -294,6 +296,7 @@ class ManagementPlugin(PluginObject):
         else:
             caller.respond(__("Unknown operation: %s") % operation)
 
+    @inlineCallbacks
     def plugins_command(self, protocol, caller, source, command, raw_args,
                         args):
         """
@@ -384,7 +387,7 @@ class ManagementPlugin(PluginObject):
             self.factory_manager.plugman.scan()
 
             name = args[1]
-            result = self.factory_manager.plugman.load_plugin(name)
+            result = yield self.factory_manager.plugman.load_plugin(name)
             info = self.factory_manager.plugman.get_plugin_info(name)
 
             if result is PluginState.AlreadyLoaded:
@@ -415,7 +418,7 @@ class ManagementPlugin(PluginObject):
 
             name = args[1]
 
-            result = self.factory_manager.plugman.reload_plugin(name)
+            result = yield self.factory_manager.plugman.reload_plugin(name)
             info = self.factory_manager.plugman.get_plugin_info(name)
 
             if result is PluginState.NotExists:
@@ -445,7 +448,7 @@ class ManagementPlugin(PluginObject):
 
             name = args[1]
 
-            result = self.factory_manager.plugman.unload_plugin(name)
+            result = yield self.factory_manager.plugman.unload_plugin(name)
             info = self.factory_manager.plugman.get_plugin_info(name)
 
             if result is PluginState.NotExists:

--- a/plugins/management/__init__.py
+++ b/plugins/management/__init__.py
@@ -350,9 +350,8 @@ class ManagementPlugin(PluginObject):
             source.respond(  # Fucking PEP8
                 "%s v%s (%s): %s" % (
                     plug.name, plug.version, plug.author, (
-                        __("Loaded") if
-                        self.factory_manager.plugman.plugin_loaded(plug.name)
-                        is not None else __("Unloaded"))
+                        __("Loaded") if self.plugins.plugin_loaded(plug.name)
+                        else __("Unloaded"))
                 ))
 
             source.respond("> %s" % plug.description)

--- a/system/core.py
+++ b/system/core.py
@@ -17,4 +17,4 @@ class Ultros(object):
         self.factory_manager.run()
 
     def stop(self):
-        self.factory_manager.unload()
+        return self.factory_manager.unload()

--- a/system/factory_manager.py
+++ b/system/factory_manager.py
@@ -204,7 +204,9 @@ class FactoryManager(object):
         self.logger.trace(_("Configured plugins: %s")
                           % ", ".join(self.main_config["plugins"]))
 
-        result = yield self.plugman.load_plugins(self.main_config.get("plugins", []))
+        result = yield self.plugman.load_plugins(
+            self.main_config.get("plugins", [])
+        )
 
         event = PluginsLoadedEvent(self, self.plugman.plugin_objects)
         self.event_manager.run_callback("PluginsLoaded", event)

--- a/system/factory_manager.py
+++ b/system/factory_manager.py
@@ -148,10 +148,11 @@ class FactoryManager(object):
         else:
             raise RuntimeError(_("Manager is already running!"))
 
+    @inlineCallbacks
     def signal_callback(self, signum, frame):
         try:
             try:
-                self.unload()
+                __ = yield self.unload()
             except Exception:
                 self.logger.exception(_("Error while unloading!"))
                 try:
@@ -420,6 +421,7 @@ class FactoryManager(object):
             return True
         return False
 
+    @inlineCallbacks
     def unload(self):
         """
         Shut down and unload everything.
@@ -430,7 +432,7 @@ class FactoryManager(object):
             self.logger.info(_("Unloading protocol: %s") % name)
             self.unload_protocol(name)
 
-        self.plugman.unload_plugins()
+        __ = yield self.plugman.unload_plugins()
 
         if reactor.running:
             try:

--- a/system/plugins/info.py
+++ b/system/plugins/info.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import weakref
 
 """
 This module contains a class that represents plugin information
@@ -9,8 +10,6 @@ if it's loaded, but this is deprecated.
 """
 
 __author__ = 'Gareth Coles'
-
-import weakref
 
 
 class Info(object):
@@ -25,7 +24,7 @@ class Info(object):
 
     def __init__(self, yaml_data, plugin_object=None):
         """
-        Instanciate the class, initializing it with a dict of data loaded
+        Instantiate the class, initializing it with a dict of data loaded
         from a .plug file and optionally a plugin object
 
         :param yaml_data: The plugin's data as loaded
@@ -37,35 +36,28 @@ class Info(object):
         if plugin_object:
             self._plugin_object = weakref.ref(plugin_object)
 
-        for key in yaml_data.keys():
-            obj = yaml_data[key]
+        if "core" in self.data:
+            core = self.data["core"]
+            self.name = core["name"]
+            self.module = core["module"]
 
-            if isinstance(obj, dict):
-                setattr(self, key, Info(obj))
-            else:
-                setattr(self, key, obj)
-
-        if self.core is not None:
-            self.name = self.core.name
-            self.module = self.core.module
-
-            if "type" in self.core:
-                self.type = self.core.type
+            if "type" in core:
+                self.type = core["type"]
             else:
                 self.type = "python"
 
-            if hasattr(self.core, "dependencies"):
-                self.dependencies = self.core.dependencies
+            if "dependencies" in core:
+                self.dependencies = core["dependencies"]
             else:
-                self.core.dependencies = []
                 self.dependencies = []
 
-        if self.info is not None:
-            self.version = self.info.version
-            self.description = self.info.description
-            self.author = self.info.author
-            self.website = self.info.website
-            self.copyright = self.info.copyright
+        if "info" in self.data:
+            info = self.data["info"]
+            self.version = info["version"]
+            self.description = info["description"]
+            self.author = info["author"]
+            self.website = info["website"]
+            self.copyright = info["copyright"]
         else:
             self.version = None
             self.description = None

--- a/system/plugins/loaders/base.py
+++ b/system/plugins/loaders/base.py
@@ -6,6 +6,8 @@ __author__ = 'Gareth Coles'
 
 class BasePluginLoader(object):
     logger_name = ""
+    name = ""
+
     factory_manager = None
     plugin_manager = None
 

--- a/system/plugins/loaders/base.py
+++ b/system/plugins/loaders/base.py
@@ -1,20 +1,26 @@
 # coding=utf-8
+from system.logging.logger import getLogger
 
 __author__ = 'Gareth Coles'
 
 
 class BasePluginLoader(object):
+    logger_name = ""
+    factory_manager = None
+    plugin_manager = None
+
+    def __init__(self):
+        self.logger = getLogger(self.logger_name)
+
+    def setup(self):
+        from system.factory_manager import FactoryManager
+        from system.plugins.manager import PluginManager
+
+        self.factory_manager = FactoryManager()
+        self.plugin_manager = PluginManager()
+
     def load_plugin(self, info):
         raise NotImplementedError()
 
-    def unload_plugin(self, name):
-        raise NotImplementedError()
-
-    def can_handle_plugin(self, info):
-        raise NotImplementedError()
-
-    def get_plugin(self, name):
-        raise NotImplementedError()
-
-    def plugin_is_loaded(self, name):
+    def can_load_plugin(self, info):
         raise NotImplementedError()

--- a/system/plugins/loaders/base.py
+++ b/system/plugins/loaders/base.py
@@ -11,15 +11,14 @@ class BasePluginLoader(object):
     factory_manager = None
     plugin_manager = None
 
-    def __init__(self):
+    def __init__(self, factory_manager, plugin_manager):
         self.logger = getLogger(self.logger_name)
 
-    def setup(self):
-        from system.factory_manager import FactoryManager
-        from system.plugins.manager import PluginManager
+        self.factory_manager = factory_manager
+        self.plugin_manager = plugin_manager
 
-        self.factory_manager = FactoryManager()
-        self.plugin_manager = PluginManager()
+    def setup(self):
+        pass
 
     def load_plugin(self, info):
         raise NotImplementedError()

--- a/system/plugins/loaders/base.py
+++ b/system/plugins/loaders/base.py
@@ -12,7 +12,7 @@ class BasePluginLoader(object):
     plugin_manager = None
 
     def __init__(self, factory_manager, plugin_manager):
-        self.logger = getLogger(self.logger_name)
+        self.logger = getLogger(self.logger_name or self.__class__.__name__)
 
         self.factory_manager = factory_manager
         self.plugin_manager = plugin_manager

--- a/system/plugins/loaders/python.py
+++ b/system/plugins/loaders/python.py
@@ -102,4 +102,3 @@ class PythonPluginLoader(BasePluginLoader):
 
     def can_load_plugin(self, info):
         return info.type == "python"
-

--- a/system/plugins/loaders/python.py
+++ b/system/plugins/loaders/python.py
@@ -4,7 +4,6 @@ import inspect
 import sys
 
 from system.enums import PluginState
-from system.factory_manager import FactoryManager
 from system.logging.logger import getLogger
 from system.plugins.loaders.base import BasePluginLoader
 from system.plugins.plugin import PluginObject
@@ -55,7 +54,7 @@ class PythonPluginLoader(BasePluginLoader):
         else:
             try:
                 info.set_plugin_object(obj)
-                obj.add_variables(info, FactoryManager())
+                obj.add_variables(info)
                 obj.logger = getLogger(info.name)
 
                 d = obj.setup()

--- a/system/plugins/loaders/python.py
+++ b/system/plugins/loaders/python.py
@@ -1,21 +1,105 @@
 # coding=utf-8
+import importlib
+import inspect
+import sys
+
+from system.enums import PluginState
+from system.factory_manager import FactoryManager
+from system.logging.logger import getLogger
 from system.plugins.loaders.base import BasePluginLoader
+from system.plugins.plugin import PluginObject
+
+from twisted.internet.defer import inlineCallbacks, Deferred, returnValue
 
 __author__ = 'Gareth Coles'
 
 
 class PythonPluginLoader(BasePluginLoader):
-    def load_plugin(self, info):
-        pass
+    logger_name = "PythonLoader"
 
-    def get_plugin(self, name):
-        pass
+    @inlineCallbacks
+    def load_plugin(self, info):  # TODO: Logging
+        module = info.get_module()
+        self.logger.trace("Module: {}".format(module))
 
-    def can_handle_plugin(self, info):
+        try:
+            if module in sys.modules:
+                self.logger.trace("Module exists, reloading..")
+                reload(sys.modules[module])
+                module_obj = sys.modules[module]
+            else:
+                module_obj = importlib.import_module(module)
+
+            self.logger.trace("Module object: {}".format(module_obj))
+
+            obj = self.find_plugin_class(module_obj)
+
+            if obj is None:
+                self.logger.error(
+                    "Unable to find plugin class for plugin: {}".format(
+                        info.name
+                    )
+                )
+                returnValue((PluginState.LoadError, None))
+
+        except ImportError:
+            self.logger.exception("Unable to import plugin: {}".format(
+                info.name
+            ))
+            returnValue((PluginState.LoadError, None))
+        except Exception:
+            self.logger.exception("Error loading plugin: {}".format(
+                info.name
+            ))
+            returnValue((PluginState.LoadError, None))
+        else:
+            try:
+                info.set_plugin_object(obj)
+                obj.add_variables(info, FactoryManager())
+                obj.logger = getLogger(info.name)
+
+                d = obj.setup()
+
+                if isinstance(d, Deferred):
+                    _ = yield d
+            except Exception:
+                self.logger.exception("Error setting up plugin: {}".format(
+                    info.name
+                ))
+                returnValue((PluginState.LoadError, None))
+            else:
+                returnValue((PluginState.Loaded, obj))
+
+    def find_plugin_class(self, module):
+        for name_, clazz in inspect.getmembers(module):
+            self.logger.trace("Member: {}".format(name_))
+            if inspect.isclass(clazz):
+                self.logger.trace("It's a class!")
+                if clazz.__module__ == module.__name__:
+                    self.logger.trace("It's the right module!")
+                    try:
+                        if self.is_plugin_class(clazz):
+                            return clazz()
+                    except RuntimeError:
+                        self.logger.exception(
+                            "Recursion limit hit while trying to import: "
+                            "{}".format(
+                                clazz.__name__
+                            )
+                        )
+                        return None
+        return None
+
+    def is_plugin_class(self, clazz):
+        for parent in clazz.__bases__:
+            if parent == PluginObject:
+                self.logger.trace("It's the right subclass!")
+                return True
+        for parent in clazz.__bases__:
+            if self.is_plugin_class(parent):
+                return True
+        return False
+
+    def can_load_plugin(self, info):
         return info.type == "python"
 
-    def unload_plugin(self, name):
-        pass
-
-    def plugin_is_loaded(self, name):
-        pass

--- a/system/plugins/loaders/python.py
+++ b/system/plugins/loaders/python.py
@@ -15,9 +15,10 @@ __author__ = 'Gareth Coles'
 
 class PythonPluginLoader(BasePluginLoader):
     logger_name = "PythonLoader"
+    name = "python"
 
     @inlineCallbacks
-    def load_plugin(self, info):  # TODO: Logging
+    def load_plugin(self, info):
         module = info.get_module()
         self.logger.trace("Module: {}".format(module))
 
@@ -54,7 +55,7 @@ class PythonPluginLoader(BasePluginLoader):
         else:
             try:
                 info.set_plugin_object(obj)
-                obj.add_variables(info)
+                obj.add_variables(info, self)
                 obj.logger = getLogger(info.name)
 
                 d = obj.setup()

--- a/system/plugins/manager.py
+++ b/system/plugins/manager.py
@@ -320,8 +320,10 @@ class PluginManager(object):
             if result is PluginState.LoadError:
                 self.log.debug("LoadError")
                 pass  # Already output by load_plugin
-            elif result is PluginState.NotExists:  # Should never happen
-                self.log.warning("No such plugin: %s" % info.name)
+            elif result is PluginState.NotExists:
+                self.log.warning(
+                    "Plugin state: NotExists (This should never happen)"
+                )
             elif result is PluginState.Loaded:
                 if output:
                     self.log.info(
@@ -428,17 +430,26 @@ class PluginManager(object):
             result = yield self.unload_plugin(key)
 
             if result is PluginState.LoadError:
-                pass  # Should never happen
+                self.log.warning(
+                    "Plugin state: LoadError (This should never happen)"
+                )
             elif result is PluginState.NotExists:
                 self.log.warning("No such plugin: {}".format(key))
             elif result is PluginState.Loaded:
-                pass  # Should never happen
+                self.log.warning(
+                    "Plugin state: Loaded (This should never happen)"
+                )
             elif result is PluginState.AlreadyLoaded:
-                pass  # Should never happen
+                self.log.warning(
+                    "Plugin state: Already Loaded (This should never happen)"
+                )
             elif result is PluginState.Unloaded:
                 pass  # Output by the unload_plugin function already
             elif result is PluginState.DependencyMissing:
-                pass  # Should never happen
+                self.log.warning(
+                    "Plugin state: DependencyMissing (This should never "
+                    "happen)"
+                )
 
     @inlineCallbacks
     def unload_plugin(self, name):
@@ -506,7 +517,9 @@ class PluginManager(object):
                 if output:
                     self.log.warning("Plugin already loaded: %s" % c_name)
             elif result is PluginState.Unloaded:
-                pass  # Should never happen
+                self.log.warning(
+                    "Plugin state: Unloaded (This should never happen)"
+                )
             elif result is PluginState.DependencyMissing:
                 pass  # Already output
 

--- a/system/plugins/manager.py
+++ b/system/plugins/manager.py
@@ -405,9 +405,8 @@ class PluginManager(object):
                 pass  # Should never happen
             elif result is PluginState.AlreadyLoaded:
                 pass  # Should never happen
-            elif result is PluginState.Unloaded:  # Should never happen
-                if output:
-                    self.log.info("Plugin unloaded: {}".format(key))
+            elif result is PluginState.Unloaded:
+                pass  # Output by the unload_plugin function already
             elif result is PluginState.DependencyMissing:
                 pass  # Should never happen
 

--- a/system/plugins/manager.py
+++ b/system/plugins/manager.py
@@ -450,6 +450,14 @@ class PluginManager(object):
                     "Plugin state: DependencyMissing (This should never "
                     "happen)"
                 )
+            else:
+                self.log.warning(
+                    "Unknown plugin state: {0} "
+                    "(This should never happen)".format(
+                        result
+                    )
+                )
+                self.log.warning("Bug the developer of '{0}'!".format(key))
 
     @inlineCallbacks
     def unload_plugin(self, name):

--- a/system/plugins/manager.py
+++ b/system/plugins/manager.py
@@ -70,7 +70,6 @@ class PluginManager(object):
         self.loaders = {}
 
         python_loader = PythonPluginLoader()
-        python_loader.setup()
         self.loaders["python"] = python_loader
 
         self.factory_manager = factory_manager
@@ -177,6 +176,8 @@ class PluginManager(object):
         :type output: bool
         """
 
+        self.loaders["python"].setup()
+
         # Plugins still needing loaded
         to_load = []
         # Final, ordered, list of plugins to load
@@ -233,7 +234,7 @@ class PluginManager(object):
 
                         if loaded.name.lower() == dep_name:
                             self.log.trace("Found a dependency")
-                            loaded_version = StrictVersion(loaded.info.version)
+                            loaded_version = StrictVersion(loaded.version)
 
                             if not operator_func(
                                     loaded_version, parsed_dep_version
@@ -330,7 +331,7 @@ class PluginManager(object):
 
         info = self.info_objects[name]
 
-        for dep in info.core.dependencies:
+        for dep in info.dependencies:
             dep = dep.lower()
 
             if " " in dep:
@@ -365,6 +366,8 @@ class PluginManager(object):
         if result is PluginState.Loaded:
             self.plugin_objects[name] = obj
 
+        returnValue(result)
+
     def unload_plugins(self, output=True):
         """
         Unload all loaded plugins
@@ -374,7 +377,9 @@ class PluginManager(object):
         """
 
         if output:
-            self.log.info("Unloading %s plugins.." % len(self.plugin_objects))
+            self.log.info(
+                "Unloading {} plugins..".format(len(self.plugin_objects))
+            )
 
         for key in self.plugin_objects.keys():
             result = self.unload_plugin(key)
@@ -382,14 +387,14 @@ class PluginManager(object):
             if result is PluginState.LoadError:
                 pass  # Should never happen
             elif result is PluginState.NotExists:
-                self.log.warning("No such plugin: %s" % key)
+                self.log.warning("No such plugin: {}".format(key))
             elif result is PluginState.Loaded:
                 pass  # Should never happen
             elif result is PluginState.AlreadyLoaded:
                 pass  # Should never happen
             elif result is PluginState.Unloaded:  # Should never happen
                 if output:
-                    self.log.info("Plugin unloaded: %s" % key)
+                    self.log.info("Plugin unloaded: {}".format(key))
             elif result is PluginState.DependencyMissing:
                 pass  # Should never happen
 

--- a/system/plugins/manager.py
+++ b/system/plugins/manager.py
@@ -91,17 +91,28 @@ class PluginManager(object):
                 return loader
         return None
 
-    def add_loader(self, name, loader):
-        if name in self.loaders:
+    def add_loader(self, loader):
+        if loader.name in self.loaders:
             return False
 
-        self.loaders[name] = loader
+        self.loaders[loader.name] = loader
         return True
 
     def remove_loader(self, name):
-        # TODO: Unload all associated plugins
         if name not in self.loaders:
             return False
+
+        to_unload = []
+        loader = self.loaders[name]
+
+        for plugin in self.plugin_objects.itervalues():
+            if plugin._loader == loader.name:
+                to_unload.append(plugin.info.name)
+
+        del loader
+
+        for plugin in to_unload:
+            self.unload_plugin(plugin)
 
         del self.loaders[name]
         return True

--- a/system/plugins/manager.py
+++ b/system/plugins/manager.py
@@ -65,7 +65,7 @@ class PluginManager(object):
         self.log = getLogger("Plugins")
         self.loaders = {}
 
-        python_loader = PythonPluginLoader()
+        python_loader = PythonPluginLoader(factory_manager, self)
         self.loaders["python"] = python_loader
 
         self.factory_manager = factory_manager

--- a/system/plugins/manager.py
+++ b/system/plugins/manager.py
@@ -13,7 +13,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 
 from system.enums import PluginState
 from system.events.manager import EventManager
-from system.events.general import PluginLoadedEvent
+from system.events.general import PluginLoadedEvent, PluginUnloadedEvent
 from system.logging.logger import getLogger
 from system.plugins.info import Info
 from system.plugins.loaders.python import PythonPluginLoader
@@ -437,10 +437,12 @@ class PluginManager(object):
         except Exception:
             self.log.exception("Error deactivating plugin: %s" % obj.info.name)
 
-        event = PluginLoadedEvent(self, obj)
+        event = PluginUnloadedEvent(self, obj)
         self.events.run_callback("PluginUnloaded", event)
 
         del self.plugin_objects[name]
+
+        self.log.info("Unloaded plugin: {}".format(name))
         return PluginState.Unloaded
 
     def reload_plugins(self, output=True):

--- a/system/plugins/plugin.py
+++ b/system/plugins/plugin.py
@@ -1,6 +1,8 @@
 # coding=utf-8
 from system.commands.manager import CommandManager
+from system.decorators.log import deprecated
 from system.events.manager import EventManager
+from system.logging.logger import getLogger
 from system.storage.manager import StorageManager
 from system.translations import Translations
 
@@ -38,6 +40,21 @@ class PluginObject(object):
     #: :type: StorageManager
     storage = None  # Storage manager
 
+    def __init__(self, info, loader):
+        from system.factory_manager import FactoryManager
+        from system.plugins.manager import PluginManager
+
+        self.commands = CommandManager()
+        self.events = EventManager()
+        self.factory_manager = FactoryManager()
+        self.info = info
+        self.logger = getLogger(info.name)
+        self.module = self.info.module
+        self.plugins = PluginManager()
+        self.storage = StorageManager()
+        self._loader = loader.name
+
+    @deprecated("This function does nothing - logic should go in __init__")
     def add_variables(self, info, loader):
         """
         Adds essential variables at load time and sets up logging
@@ -48,18 +65,7 @@ class PluginObject(object):
         :param info: The plugin info file
         :type info: Info instance
         """
-
-        from system.plugins.manager import PluginManager
-        from system.factory_manager import FactoryManager
-
-        self.commands = CommandManager()
-        self.events = EventManager()
-        self.factory_manager = FactoryManager()
-        self.info = info
-        self.module = self.info.module
-        self.plugins = PluginManager()
-        self.storage = StorageManager()
-        self._loader = loader.name
+        pass
 
     def deactivate(self):
         """

--- a/system/plugins/plugin.py
+++ b/system/plugins/plugin.py
@@ -38,7 +38,7 @@ class PluginObject(object):
     #: :type: StorageManager
     storage = None  # Storage manager
 
-    def add_variables(self, info, factory_manager):
+    def add_variables(self, info):
         """
         Adds essential variables at load time and sets up logging
 
@@ -47,16 +47,14 @@ class PluginObject(object):
 
         :param info: The plugin info file
         :type info: Info instance
-
-        :param factory_manager: The factory manager
-        :type factory_manager: system.factory_manager.FactoryManager
         """
 
         from system.plugins.manager import PluginManager
+        from system.factory_manager import FactoryManager
 
         self.commands = CommandManager()
         self.events = EventManager()
-        self.factory_manager = factory_manager
+        self.factory_manager = FactoryManager()
         self.info = info
         self.module = self.info.module
         self.plugins = PluginManager()

--- a/system/plugins/plugin.py
+++ b/system/plugins/plugin.py
@@ -38,7 +38,7 @@ class PluginObject(object):
     #: :type: StorageManager
     storage = None  # Storage manager
 
-    def add_variables(self, info):
+    def add_variables(self, info, loader):
         """
         Adds essential variables at load time and sets up logging
 
@@ -59,6 +59,7 @@ class PluginObject(object):
         self.module = self.info.module
         self.plugins = PluginManager()
         self.storage = StorageManager()
+        self._loader = loader.name
 
     def deactivate(self):
         """


### PR DESCRIPTION
This adds the following to Ultros:

* Support for plugins of different types
    * This is achieved by allowing plugins to themselves register loaders for other plugin types
    * Naturally, this means that Python plugins have their own modular loader - this can be unloaded by plugins too, but I don't really recommend that
* Support for Deferreds in various places
    * The plugin manager (and factory manager) is now able to deal with plugins returning Deferreds in their `setup()` and `deactivate()` functions
    * Of course, this means that more parts of the plugin manager return Deferreds now - Specifically:
        * `remove_loader(name)`
        * `load_plugins(plugins, output=True)`
        * `load_plugin(name)`
        * `unload_plugins(output=True)`
        * `unload_plugin(name)`
        * `reload_plugin(name)`
    * The docstrings for these have been updated appropriately for the api docs